### PR TITLE
New graph2vec implementation

### DIFF
--- a/config/test/do-pairs/ASD+SVM+Graph2Vec_DCE.jsonc
+++ b/config/test/do-pairs/ASD+SVM+Graph2Vec_DCE.jsonc
@@ -1,0 +1,38 @@
+{  
+    "experiment" : {
+        "scope": "svm_oracle",
+        "parameters" : {
+            "lock_release_tout":120,
+            "propagate":[
+                {"in_sections" : ["explainers"],"params" : {"fold_id": 0}},
+                {"in_sections" : ["do-pairs/oracle"],"params" : {"fold_id": -1,"retrain":true}},
+                {"in_sections": ["do-pairs/dataset"],"params": { "compose_mes" : "config/snippets/centr_and_weights.json" }}
+            ]
+        }
+    },
+    "do-pairs":[ 
+        {
+            "dataset": {
+                "class": "src.n_dataset.dataset_base.Dataset",
+                "parameters": {
+                    "generator": {
+                        "class": "src.n_dataset.generators.asd.ASD", 
+                        "parameters": { "data_dir": "data/datasets/autism/" }
+                    }
+                }
+            },
+            "oracle": {
+                "class": "src.oracle.tabulars.svm.SVMOracle",
+                "parameters": {
+                    "embedder": {
+                        "class": "src.embedder.newgraph2vec.model.Graph2VecEmbedder", 
+                        "parameters": { "wl_iterations": 17 }
+                    }
+                }
+            }
+        }
+        ],
+    "explainers": [{"class": "src.explainer.search.dce.DCESearchExplainer"}],
+    "compose_mes" : "config/snippets/default_metrics.json",
+    "compose_strs" : "config/snippets/default_store_paths.json"
+}

--- a/src/embedder/newgraph2vec/graph2vec_model.py
+++ b/src/embedder/newgraph2vec/graph2vec_model.py
@@ -1,0 +1,44 @@
+import hashlib
+import networkx as nx
+
+class WeisfeilerLehmanMachine:
+    """
+    Weisfeiler Lehman feature extractor class.
+    """
+    def __init__(self, graph: nx.classes.graph.Graph, features: dict, iterations: int):
+        """
+        Initialization method which also executes feature extraction.
+        :param graph: The Nx graph object.
+        :param features: Feature hash table.
+        :param iterations: Number of WL iterations.
+        """
+        self.iterations = iterations
+        self.graph = graph
+        self.features = features
+        self.nodes = self.graph.nodes()
+        self.extracted_features = [str(v) for _, v in features.items()]
+        self.do_recursions()
+
+    def do_a_recursion(self):
+        """
+        The method does a single WL recursion.
+        :return new_features: The hash table with extracted WL features.
+        """
+        new_features = {}
+        for node in self.nodes:
+            nebs = self.graph.neighbors(node)
+            degs = [self.features[neb] for neb in nebs]
+            features = [str(self.features[node])]+sorted([str(deg) for deg in degs])
+            features = "_".join(features)
+            hash_object = hashlib.md5(features.encode())
+            hashing = hash_object.hexdigest()
+            new_features[node] = hashing
+        self.extracted_features = self.extracted_features + list(new_features.values())
+        return new_features
+
+    def do_recursions(self):
+        """
+        The method does a series of WL recursions.
+        """
+        for _ in range(self.iterations):
+            self.features = self.do_a_recursion()

--- a/src/embedder/newgraph2vec/model.py
+++ b/src/embedder/newgraph2vec/model.py
@@ -1,0 +1,86 @@
+import numpy as np
+from gensim.models.doc2vec import Doc2Vec, TaggedDocument
+from src.core.embedder_base import Embedder
+from src.embedder.newgraph2vec.graph2vec_model import WeisfeilerLehmanMachine
+from src.n_dataset.instances.graph import GraphInstance
+import networkx as nx
+
+
+class Graph2VecEmbedder(Embedder):
+    def init(self):
+        self.wl_iterations = self.local_config['parameters']['wl_iterations']
+        self.dimensions = self.local_config['parameters']['dimensions']
+        self.min_count = self.local_config['parameters']['min_count']
+        self.down_sampling = self.local_config['parameters']['down_sampling']
+        self.workers = self.local_config['parameters']['workers']
+        self.epochs = self.local_config['parameters']['epochs']
+        self.learning_rate = self.local_config['parameters']['learning_rate']
+        self.seed = self.local_config['parameters']['seed']
+        self.selected_feature = self.local_config['parameters']['selected_feature']
+        self._embedding = None
+
+    # todo support more than one feature
+    def get_embeddings(self):
+        print(self.dataset)
+        return np.array(self._embedding)
+
+    def get_embedding(self, instance: GraphInstance):
+        features = self._get_instace_features(instance)
+        document = WeisfeilerLehmanMachine(instance.get_nx(), features, self.wl_iterations)
+        document = TaggedDocument(words=document.extracted_features, tags=[str(0)])
+        return np.array(self.model.infer_vector(document.words)).reshape(1, -1)
+
+    def real_fit(self):
+        documents = [
+            WeisfeilerLehmanMachine(
+                graph.get_nx(), self._get_instace_features(graph), self.wl_iterations
+            )
+            for graph in self.dataset.instances
+        ]
+        documents = [
+            TaggedDocument(words=doc.extracted_features, tags=[str(i)])
+            for i, doc in enumerate(documents)
+        ]
+
+        self.model = Doc2Vec(
+            documents,
+            vector_size=self.dimensions,
+            window=0,
+            min_count=self.min_count,
+            dm=0,
+            sample=self.down_sampling,
+            workers=self.workers,
+            epochs=self.epochs,
+            alpha=self.learning_rate,
+            seed=self.seed,
+        )
+        self._embedding = [self.model.docvecs[str(i)] for i, _ in enumerate(documents)]
+
+    def check_configuration(self):
+        super().check_configuration()
+        self.local_config['parameters']['wl_iterations'] =  self.local_config['parameters'].get('wl_iterations', 2)
+        self.local_config['parameters']['dimensions'] =  self.local_config['parameters'].get('dimensions', 128)
+        self.local_config['parameters']['min_count'] =  self.local_config['parameters'].get('min_count', 5)
+        self.local_config['parameters']['down_sampling'] =  self.local_config['parameters'].get('down_sampling', 0.0001)
+        self.local_config['parameters']['workers'] =  self.local_config['parameters'].get('workers', 4)
+        self.local_config['parameters']['epochs'] =  self.local_config['parameters'].get('epochs', 10)
+        self.local_config['parameters']['learning_rate'] =  self.local_config['parameters'].get('learning_rate', 0.025)
+        self.local_config['parameters']['seed'] =  self.local_config['parameters'].get('seed', 42)
+        self.local_config['parameters']['selected_feature'] =  self.local_config['parameters'].get('selected_feature', None)
+
+    def _get_instace_features(self, instance: GraphInstance):
+        feature = self.selected_feature if self.selected_feature in self.dataset.node_features_map.keys() else 'degrees'
+
+        if feature in self.dataset.node_features_map.keys():
+            key = self.dataset.node_features_map[feature]
+            
+            values =  {i:elem for i,elem in enumerate(instance.node_features[:,key])}
+            return values
+
+        graph = instance.get_nx()
+        
+        return { node: graph.degree(node) for node in graph.nodes() }
+
+        
+
+        

--- a/src/embedder/newgraph2vec/model.py
+++ b/src/embedder/newgraph2vec/model.py
@@ -21,7 +21,6 @@ class Graph2VecEmbedder(Embedder):
 
     # todo support more than one feature
     def get_embeddings(self):
-        print(self.dataset)
         return np.array(self._embedding)
 
     def get_embedding(self, instance: GraphInstance):


### PR DESCRIPTION
Implementation without Karateclub's dependencies.

Example configuration file provided at 

> config\test\do-pairs\ASD+SVM+Graph2Vec_DCE.jsonc

There is a problem with embedder training that involves core changes. If someone want to test this changes. A hotfix is needed. Add the next lines to the real_fit() call of the tabular_base class of the oracles:

`def real_fit(self):`
       `self.embedder.fit()`
        `....`
