### PR TITLE
Dce implementation using rank manipulator

### DIFF
--- a/config/test/do-pairs/ASD+GCN_DCERank.jsonc
+++ b/config/test/do-pairs/ASD+GCN_DCERank.jsonc
@@ -1,0 +1,23 @@
+{  
+    "experiment" : {
+        "scope": "gcn_oracle",
+        "parameters" : {
+            "lock_release_tout":120,
+            "propagate":[
+                {"in_sections" : ["explainers"],"params" : {"fold_id": 0}},
+                {"in_sections" : ["do-pairs/oracle"],"params" : {"fold_id": -1,"retrain":true}},
+                {"in_sections": ["do-pairs/dataset"],"params": 
+                { "manipulators": [
+                    { "class": "src.n_dataset.manipulators.centralities.NodeCentrality", "parameters": {} },
+                    { "class": "src.n_dataset.manipulators.weights.EdgeWeights", "parameters": {} },
+                    { "class": "src.n_dataset.manipulators.rank.RankManipulator", "parameters": {} }      
+                    ] }}
+            ]
+        }
+    },
+    "do-pairs":[ {"compose_bbbp_gcn" : "config/snippets/do-pairs/ASD-GCN.json"}
+        ],
+    "explainers": [{"class": "src.explainer.search.dcerank.DCESearchExplainerWithRank"}],
+    "compose_mes" : "config/snippets/default_metrics.json",
+    "compose_strs" : "config/snippets/default_store_paths.json"
+}

--- a/src/explainer/search/dcerank.py
+++ b/src/explainer/search/dcerank.py
@@ -1,0 +1,66 @@
+import copy
+import sys
+
+from src.core.explainer_base import Explainer
+from src.evaluation.evaluation_metric_ged import GraphEditDistanceMetric
+import numpy as np
+
+
+class DCESearchExplainerWithRank(Explainer):
+
+    # Todo improve configuration and default values
+    def init(self):
+        super().init()
+        self._gd = GraphEditDistanceMetric()
+        self.fold_id=-1        
+        self.dist_mat = np.full((len(self.dataset.instances), len(self.dataset.instances)), -1)
+        self.cls_mat = np.full((len(self.dataset.instances), len(self.dataset.instances)), -1)
+
+
+    def explain(self, instance):
+        l_input_inst = self.oracle.predict(instance)
+
+        # if the method does not find a counterfactual example returns the original graph
+        min_counterfactual = instance
+
+        if "distance_rank_index" in instance.dataset.graph_features_map.keys() and "distance_rank_value" in instance.dataset.graph_features_map.keys():
+            rank_index = instance.dataset.graph_features_map["distance_rank_index"]
+            rank_values_index = instance.dataset.graph_features_map["distance_rank_value"]        
+
+            rank = [ int(x) for x in instance.graph_features[:,rank_index]]
+
+            for value in rank:
+                _inst = [x for x in self.dataset.instances if x.id == value][0]
+                l_data_inst = self.oracle.predict(_inst)
+
+                if l_data_inst != l_input_inst:
+                    min_counterfactual = _inst
+        
+        # if manipulation data is not present, then use the legacy implementation of the dce
+        else:
+            for d_inst in self.dataset.instances:
+                if self.cls_mat[instance.id,d_inst.id] == -1:
+                    l_data_inst = self.oracle.predict(d_inst)
+                    self.cls_mat[instance.id,d_inst.id] = (l_input_inst == l_data_inst)
+                    self.cls_mat[d_inst.id,instance.id] = (l_input_inst == l_data_inst)
+
+                if self.cls_mat[instance.id,d_inst.id] == 0:
+                    if self.dist_mat[instance.id,d_inst.id] == -1:                
+                        d_inst_dist = self._gd.evaluate(instance, d_inst, self.oracle)
+                        self.dist_mat[instance.id,d_inst.id]=d_inst_dist
+                        self.dist_mat[d_inst.id,instance.id]=d_inst_dist
+
+                    d_inst_dist=self.dist_mat[instance.id,d_inst.id]
+                    if (d_inst_dist < min_counterfactual_dist):                
+                        min_counterfactual_dist = d_inst_dist
+                        min_counterfactual = d_inst
+
+        results = copy.deepcopy(min_counterfactual)
+        results.id = instance.id
+
+        return results
+
+
+
+
+

--- a/src/explainer/search/dcerank.py
+++ b/src/explainer/search/dcerank.py
@@ -1,9 +1,9 @@
 import copy
-import sys
+import numpy as np
 
 from src.core.explainer_base import Explainer
 from src.evaluation.evaluation_metric_ged import GraphEditDistanceMetric
-import numpy as np
+from src.n_dataset.instances.graph import GraphInstance
 
 
 class DCESearchExplainerWithRank(Explainer):
@@ -17,15 +17,14 @@ class DCESearchExplainerWithRank(Explainer):
         self.cls_mat = np.full((len(self.dataset.instances), len(self.dataset.instances)), -1)
 
 
-    def explain(self, instance):
+    def explain(self, instance: GraphInstance):
         l_input_inst = self.oracle.predict(instance)
 
         # if the method does not find a counterfactual example returns the original graph
         min_counterfactual = instance
 
-        if "distance_rank_index" in instance.dataset.graph_features_map.keys() and "distance_rank_value" in instance.dataset.graph_features_map.keys():
-            rank_index = instance.dataset.graph_features_map["distance_rank_index"]
-            rank_values_index = instance.dataset.graph_features_map["distance_rank_value"]        
+        if "distance_rank_index" in self.dataset.graph_features_map.keys():
+            rank_index = self.dataset.graph_features_map["distance_rank_index"]   
 
             rank = [ int(x) for x in instance.graph_features[:,rank_index]]
 

--- a/src/n_dataset/manipulators/rank.py
+++ b/src/n_dataset/manipulators/rank.py
@@ -1,0 +1,23 @@
+import networkx as nx
+import numpy as np
+
+from src.n_dataset.manipulators.base import BaseManipulator
+from src.evaluation.evaluation_metric_ged import GraphEditDistanceMetric
+
+
+class RankManipulator(BaseManipulator):
+    def graph_info(self, instance):
+
+        distance = GraphEditDistanceMetric()
+
+        result = [ (distance.evaluate(instance, x), x.id) for x in self.dataset.instances]
+
+        result.sort(key=lambda x: x[0])
+
+        dist = [ x for (x,_) in result]
+        index = [y for (_,y) in result]
+
+        return { 
+            "distance_rank_index" : index, 
+            "distance_rank_value": dist
+            }


### PR DESCRIPTION
Implementation of the dce explainer using a distance rank for each instance.

The rank manipulator generates two properties/lists both sorted by distance
"distance_rank_index" keeps the ith instance id and
"distance_rank_value" keeps the distance value from the current instance related to the ith instance

I remember you suggest me some changes to the output of the rank, but i do not remember them @bardhprenkaj. 